### PR TITLE
Adding content-type 'text/html' for IndexAction.

### DIFF
--- a/application/modules/Workbench/Controller/Index.php
+++ b/application/modules/Workbench/Controller/Index.php
@@ -68,6 +68,7 @@ class Workbench_Controller_Index extends Zend_Controller_Action
         $r = Glitch_Registry::getSettings()->workbench;
         $m = new Workbench_Model_Workbench_EntryPoints();
 
+        $this->getResponse()->setHeader('Content-Type', 'text/html');
         $this->view->resources = $m->getResources($r->scanPaths, $r->fileToClassStrip, $r->additionalIncludes);
     }
 


### PR DESCRIPTION
By adding an explicit content-type for the IndexAction, we can implicitly set the content-type of our REST API to 'text/xml', and still use the REST Workbench. Also, adding a content-type won't hurt.
