### PR TITLE
Change oAuth client to incorporate body in signature under specific circumstances

### DIFF
--- a/application/modules/Workbench/Controller/Index.php
+++ b/application/modules/Workbench/Controller/Index.php
@@ -362,9 +362,13 @@ class Workbench_Controller_Index extends Zend_Controller_Action
             //Apparently you need to provide all values that you send to do signing
             //$signParams = $query;
             $signParams = null;
-            if ('post' === $core['http_method'] && isset($p['params']) && is_array($p['params']) && !$modifyClient) {
+            if (
+                ('post' === $core['http_method'] && isset($p['params']) && is_array($p['params']) && !$modifyClient) ||
+                ('post' == $core['http_method'] && 'application/x-www-form-urlencoded' == $r->getServer('CONTENT_TYPE'))
+            ) {
                 $signParams = array_merge($queryStringParts, $p['params']);
             }
+
             // Generate request and sign it
             $request = OAuthRequest::from_consumer_and_token(
                 $consumer,


### PR DESCRIPTION
Currently the oAuth signature generation misses a key component when the content type is `application/x-www-form-urlencoded`. If this is the given content-type, the contents of the POST array also have to be part of the signature. For more info see [the oAuth spec](http://tools.ietf.org/html/rfc5849#section-3.5.2) regarding this.

This bug currently causes erroneous behaviour when connecting to the Autotrack API.
